### PR TITLE
Fix CV link path in Hero component

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -37,7 +37,7 @@ import Briefcase from "./icons/Briefcase.astro"
       He reducido costos cloud en <strong>40%</strong> y automatizado workflows que ahorran <strong>20+ horas</strong> semanales.
     </p>
   <nav class="flex flex-wrap gap-4 mt-8">
-    <SocialPill href="public/cv/BryanAvilaCVEspanol.pdf">
+    <SocialPill href="/cv/BryanAvilaCVEspanol.pdf">
       <Briefcase class="size-4" />
       Ver CV
     </SocialPill>


### PR DESCRIPTION
Updated the href for the CV download button from a relative 'public/cv/' path to an absolute '/cv/' path to ensure correct file access.